### PR TITLE
Fixed bug with toast audio silent="true"

### DIFF
--- a/Source/NotificationsExtensions/ToastContent/ToastNotificationBase.cs
+++ b/Source/NotificationsExtensions/ToastContent/ToastNotificationBase.cs
@@ -54,7 +54,7 @@
                 builder.Append("<audio");
                 if (this.Audio.Content == ToastAudioContent.Silent)
                 {
-                    builder.Append(" silent='true'/>");
+                    builder.Append(" silent='true'");
                 }
                 else
                 {


### PR DESCRIPTION
The code was appending `silent='true'/>` and then later appending an additional `/>` closing tag, resulting in invalid XML, which causes notifications to not display on Windows 10.

Removed the initial closing tag to be consistent with the rest of the code, since the closing tag is added at the end of the if/else clause.
